### PR TITLE
AI: Fix quote widget to handle quotes with double quotes.

### DIFF
--- a/_includes/homepage.html
+++ b/_includes/homepage.html
@@ -47,8 +47,8 @@
   const quotes = [
   {% for quote in site.data.quotes %}
     {
-      quote: "{{ quote.quote }}", 
-      author: "{% if quote.author %}{{ quote.author }}{% endif %}" 
+      quote: "{{ quote.quote | escape }}", 
+      author: "{% if quote.author %}{{ quote.author | escape }}{% endif %}" 
     },
   {% endfor %}
 ];


### PR DESCRIPTION
The quote widget was failing to display quotes with double quotes within them. This change updates the widget to properly escape quotes using the filter, ensuring that double quotes are handled correctly. Because of this change, the quotes will now be displayed properly, even if they contain double quotes.