### PR TITLE
AI: Fix apostrophe rendering in quote generator.

### DIFF
--- a/_includes/homepage.html
+++ b/_includes/homepage.html
@@ -47,8 +47,8 @@
   const quotes = [
   {% for quote in site.data.quotes %}
     {
-      quote: "{{ quote.quote | escape }}", 
-      author: "{% if quote.author %}{{ quote.author | escape }}{% endif %}" 
+      quote: "{{ quote.quote }}", 
+      author: "{% if quote.author %}{{ quote.author }}{% endif %}" 
     },
   {% endfor %}
 ];


### PR DESCRIPTION
The quote generator was incorrectly rendering apostrophes as . This was caused by the  filter in . This commit removes the  filter, so that apostrophes render correctly. Due to the test environment being unavailable, automated testing could not be performed. Manual inspection suggests the issue is resolved.