### PR TITLE
Add staggered fade-in-up animation

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -180,13 +180,19 @@ a:hover{
   }
 }
 
-header, main > *, footer {
+header:not(.sitetitle), main > *:not(.sitetitle), footer:not(.sitetitle) {
   opacity: 0;
-  animation: fadeInUp 0.8s ease-out forwards;
+  animation: fadeInUp 0.6s ease-out forwards;
 }
 
-header {
+header:not(.sitetitle) {
   animation-delay: 0.1s;
+}
+
+.sitetitle {
+  animation: none !important;
+  opacity: 1 !important;
+  transform: none !important;
 }
 
 main > *:nth-child(1) { animation-delay: 0.2s; }

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -180,19 +180,13 @@ a:hover{
   }
 }
 
-header:not(.sitetitle), main > *:not(.sitetitle), footer:not(.sitetitle) {
+header > *:not(:has(.sitetitle)):not(.sitetitle), main > *:not(.sitetitle), footer:not(.sitetitle) {
   opacity: 0;
   animation: fadeInUp 0.6s ease-out forwards;
 }
 
-header:not(.sitetitle) {
+header > *:not(:has(.sitetitle)):not(.sitetitle) {
   animation-delay: 0.1s;
-}
-
-.sitetitle {
-  animation: none !important;
-  opacity: 1 !important;
-  transform: none !important;
 }
 
 main > *:nth-child(1) { animation-delay: 0.2s; }
@@ -212,15 +206,15 @@ main > *:nth-child(14) { animation-delay: 1.5s; }
 main > *:nth-child(15) { animation-delay: 1.6s; }
 main > *:nth-child(n+16) { animation-delay: 1.7s; }
 
-footer {
+footer:not(.sitetitle) {
   animation-delay: 1.8s;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  header, main > *, footer {
-    animation: none;
-    opacity: 1;
-    transform: none;
+  header > *:not(:has(.sitetitle)):not(.sitetitle), main > *:not(.sitetitle), footer:not(.sitetitle) {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
   }
 }
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -168,6 +168,56 @@ a:hover{
   }
 }*/
 
+/* Fade in up animation */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+header, main > *, footer {
+  opacity: 0;
+  animation: fadeInUp 0.8s ease-out forwards;
+}
+
+header {
+  animation-delay: 0.1s;
+}
+
+main > *:nth-child(1) { animation-delay: 0.2s; }
+main > *:nth-child(2) { animation-delay: 0.3s; }
+main > *:nth-child(3) { animation-delay: 0.4s; }
+main > *:nth-child(4) { animation-delay: 0.5s; }
+main > *:nth-child(5) { animation-delay: 0.6s; }
+main > *:nth-child(6) { animation-delay: 0.7s; }
+main > *:nth-child(7) { animation-delay: 0.8s; }
+main > *:nth-child(8) { animation-delay: 0.9s; }
+main > *:nth-child(9) { animation-delay: 1.0s; }
+main > *:nth-child(10) { animation-delay: 1.1s; }
+main > *:nth-child(11) { animation-delay: 1.2s; }
+main > *:nth-child(12) { animation-delay: 1.3s; }
+main > *:nth-child(13) { animation-delay: 1.4s; }
+main > *:nth-child(14) { animation-delay: 1.5s; }
+main > *:nth-child(15) { animation-delay: 1.6s; }
+main > *:nth-child(n+16) { animation-delay: 1.7s; }
+
+footer {
+  animation-delay: 1.8s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  header, main > *, footer {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
 /* Base styles overrides */
 
 main h1, main .h1, main h2, main .h2, main h3, main .h3, main h4, main .h4, main h5, main .h5, main h6, main .h6 {


### PR DESCRIPTION
This submission addresses the user's request to add a minimalist fade-in-up animation on page elements across the website using pure CSS.

Changes include:
- A new `@keyframes fadeInUp` definition in `_sass/_custom.scss` that handles transitioning `opacity` from 0 to 1 and `transform: translateY(20px)` to 0.
- Application of the animation to `header`, `main > *` and `footer` tags.
- Incremental `animation-delay` setup using `:nth-child(n)` to create the staggered cascade effect.
- Implementation of a fallback media query targeting `(prefers-reduced-motion: reduce)` to disable animations for accessibility.

The code avoids making changes to elements impacted by view transitions and does not modify HTML structure or rely on JS. Unwanted runtime artifacts generated during dev server/bundle test runs were cleaned up before submission to keep the commit tidy.

---
*PR created automatically by Jules for task [2372154761045938652](https://jules.google.com/task/2372154761045938652) started by @keivanz*